### PR TITLE
Fix Vercel deployment configuration and add paper trading system

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -8,7 +8,7 @@ import os
 # Add the parent directory to the path so we can import our modules
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from datetime import datetime
 from typing import List
@@ -19,7 +19,8 @@ import json
 try:
     from src.engine.bot import ArbitrageBot
     from src.config.environment import env
-except ImportError:
+except ImportError as e:
+    print(f"Import error: {e}")
     # Fallback for Vercel environment where some imports might fail
     ArbitrageBot = None
     env = None
@@ -242,6 +243,16 @@ async def execute_trade(idea_id: str):
 
 # Export the FastAPI app for Vercel
 handler = app
+
+# For local development
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+# Vercel serverless handler
+def handler(request: Request):
+    """Main handler for Vercel"""
+    return app
 
 # For local development
 if __name__ == "__main__":

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -24,7 +24,7 @@ switch ($choice) {
         Write-Host "🧪 Deploying Paper Trading Environment..." -ForegroundColor Blue
         
         # Deploy with paper trading settings
-        vercel --prod `
+        vercel deploy --prod `
             --env TRADING_MODE=paper `
             --env ENVIRONMENT=development `
             --env MIN_VOLUME=1000 `
@@ -79,7 +79,7 @@ switch ($choice) {
         }
         
         # Deploy with live trading settings
-        vercel --prod `
+        vercel deploy --prod `
             --env TRADING_MODE=live `
             --env ENVIRONMENT=production `
             --env MIN_VOLUME=1000 `

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,10 @@
 {
-  "functions": {
-    "api/index.py": {
-      "runtime": "python3.9"
+  "builds": [
+    {
+      "src": "api/index.py",
+      "use": "@vercel/python"
     }
-  },
+  ],
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
- Updated vercel.json to use @vercel/python builder
- Fixed API handler for serverless deployment
- Added complete paper trading system with directional arbitrage
- Created environment-based configuration (paper vs live trading)
- Added capital management and risk controls
- Fixed arbitrage strategy to use realistic buy-only trades